### PR TITLE
add show-stderr flag to benchmark CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run benchmarks
         run: |
           asv machine --yes
-          asv run "master -n 2" --strict
+          asv run "master -n 2" --strict --show-stderr
           asv publish
       
       - name: Make pages folder


### PR DESCRIPTION
This will help future debugging of failing benchmarks in the future.