### PR TITLE
Upgrade workflows to Node 24 actions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,12 +7,12 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.13
 
       - name: Checkout benchmark
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: cvxpy/benchmarks
           ref: main
@@ -23,7 +23,7 @@ jobs:
           pip install .
       
       - name: Checkout deployed branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: cvxpy/benchmarks
           ref: gh-pages
@@ -49,7 +49,7 @@ jobs:
           mv docs pages/
       
       - name: Deploy HTML and Results Artifacts
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           folder: pages/
           repository-name: cvxpy/benchmarks

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,8 +7,8 @@ jobs:
   linters:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.13
       - name: Install dependencies

--- a/.github/workflows/pr_benchmark_comment.yml
+++ b/.github/workflows/pr_benchmark_comment.yml
@@ -9,7 +9,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download artifact
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
         # Script taken from official github documentation. 
         # Link: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
@@ -48,7 +48,7 @@ jobs:
           echo "::set-output name=number::$number"
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v4
         id: fc
         with:
           issue-number: ${{ steps.get-pr-number.outputs.number }}
@@ -56,7 +56,7 @@ jobs:
 
       - name: Create comment
         if: steps.fc.outputs.comment-id == ''
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ steps.get-pr-number.outputs.number }}
           body: |
@@ -64,7 +64,7 @@ jobs:
 
       - name: Update comment
         if: steps.fc.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           body: |

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -7,12 +7,12 @@ jobs:
   pr_benchmarks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.13
     
       - name: Checkout cvxpy
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -21,7 +21,7 @@ jobs:
           pip install .
 
       - name: Checkout benchmark
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: cvxpy/benchmarks
           ref: main
@@ -49,7 +49,7 @@ jobs:
           echo $PR_NUMBER > ./benchmark/comment_log/pr_number
 
       - name: Upload the artifact folder
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: comment_log
           path: benchmark/comment_log/

--- a/.github/workflows/test_pre_release_dependencies.yml
+++ b/.github/workflows/test_pre_release_dependencies.yml
@@ -11,10 +11,10 @@ jobs:
   test_pre_release_dependencies:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.13
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: cvxpy/cvxpy
 


### PR DESCRIPTION
## Summary
- upgrade reusable workflows from Node 20/16 action versions to Node 24-compatible versions
- update checkout, setup-python, upload-artifact, github-script, Peter Evans comment actions, and the Pages deploy action