### PR TITLE
Reduce PR-benchmark variance: drop --quick, sample with statistics

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -39,7 +39,9 @@ jobs:
       - name: Run benchmarks
         run: |
           asv machine --yes
-          asv run "master -n 2" --strict --show-stderr
+          # -a number=1: each sample must be one fresh compile. get_problem_data caches
+          # on the Problem, so timing it more than once per setup measures the cache.
+          asv run "master -n 2" -a number=1 --strict --show-stderr
           asv publish
       
       - name: Make pages folder

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -34,11 +34,21 @@ jobs:
           pip install clarabel scs osqp
       
       - name: Run benchmarks
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           cd benchmark/
           asv machine --config asv_pr.conf.json --yes
-          asv continuous origin/${{github.base_ref}} HEAD --config asv_pr.conf.json --quick --strict
-          asv compare origin/${{github.base_ref}} HEAD --config asv_pr.conf.json --split --sort ratio | tee -a asv_compare.log
+          # Drop --quick: it took a single, no-warmup sample per benchmark and compared
+          # the two raw numbers against --factor, so any >10% runner blip tripped --strict.
+          # Without it asv takes several warm samples in separate processes and compares
+          # medians with a significance test. -a number=1 keeps each sample one fresh
+          # compile: get_problem_data caches on the Problem, so a second timed call would
+          # measure the cache rather than the compilation.
+          asv continuous "origin/$BASE_REF" HEAD --config asv_pr.conf.json \
+            -a number=1 --interleave-rounds --factor 1.25 --strict
+          asv compare "origin/$BASE_REF" HEAD --config asv_pr.conf.json \
+            --factor 1.25 --split --sort ratio | tee -a asv_compare.log
           mkdir comment_log
           mv asv_compare.log comment_log/
       


### PR DESCRIPTION
## What

The PR benchmark gate runs `asv continuous origin/<base> HEAD --quick --strict`. `--quick` forces `number=1, repeat=1, warmup_time=0, rounds=1` — a single, cold sample per benchmark. With only one sample asv has no variance estimate, so it falls back to comparing the two raw numbers against `--factor` (default **1.1 = 10%**).

On a shared `ubuntu-latest` runner a single compile-time sample has a coefficient of variation near **18%** with a >2× spread (measured locally on an *idle* machine — CI is noisier). So noise alone routinely clears the 10% threshold and fails `--strict`. The median of a few samples drops CV below 3%.

## Changes

`pr_benchmarks.yml`:
- **Drop `--quick`** → asv takes several warm samples in separate processes and compares **medians with a significance test**. Its sampling is time-capped per process, so cost stays bounded.
- **`-a number=1`** → each timed call must be one fresh compile. `get_problem_data` caches its result on the `Problem`, so timing it more than once per `setup()` would measure cache retrieval, not compilation. `--quick` masked this by only ever calling once; without that guard a fast benchmark could pick `number>1` and silently time the cache.
- **`--interleave-rounds`** → interleave base/HEAD rounds to remove ordering bias.
- **`--factor 1.25`** → with real statistics now gating regressions, widen the factor so the still-blocking `--strict` fires only on significant, sizeable changes.
- Move `github.base_ref` into an `env:` var instead of interpolating it into the run script.

`benchmarks.yml` (master trend): add `-a number=1` for the same cache-correctness reason.

## Companion PR

Pairs with cvxpy/benchmarks#31 (seed the remaining unseeded benchmark setups so base and HEAD compile identical inputs). The two are independent — this PR is already a strict improvement on its own, since without `--quick` asv uses its multi-sample defaults regardless.

## Notes
- No merge-order dependency between the two PRs.
- Trade-off accepted: real sampling costs more wall-clock than a single `--quick` sample; asv's time-capped adaptive sampling keeps it bounded. A future `setup_cache` refactor of the heaviest benchmarks (CVaR, large matrix-stuffing) could buy back more headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)